### PR TITLE
[Issue 16] Add Grype for vulnerability scanning

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,18 @@
+# List of vulnerabilities to ignore for the anchore scan
+# https://github.com/anchore/grype#specifying-matches-to-ignore
+# More info can be found in the https://github.com/navapbc/template-infra/blob/main/docs/infra/vulnerability-management.md file
+
+# Please add safelists in the following format to make it easier when checking
+# Package/module name: URL to vulnerability for checking updates
+#  Versions:     URL to the version history
+#  Dependencies: Name of any other packages or modules that are dependent on this version
+#                 Link to the dependencies for ease of checking for updates
+#  Issue:         Why there is a finding and why this is here or not been removed
+#  Last checked:  Date last checked in scans
+# - vulnerability: The-CVE-or-vuln-id # Remove comment at start of line
+
+ignore:
+  # These settings ignore any findings that fall into these categories
+  - fix-state: not-fixed
+  - fix-state: wont-fix
+  - fix-state: unknown

--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -32,11 +32,10 @@ fi
 
 echo "Copying files from $template_name..."
 # Note: Keep this list of paths in sync with INCLUDE_PATHS in update-template.sh
-# @TODO: Add .grype.yml
-# See https://github.com/navapbc/template-application-rails/issues/16
 cp -r \
   .github \
   .gitignore \
+  .grype.yml \
   "${app_name}" \
   docker-compose.yml \
   docker-compose.mock-production.yml \


### PR DESCRIPTION
## Ticket

- Resolves #16 

## Changes

- Added .grype.yml file to root directory
- Added .grype.yml to the template-only-bin/install-template.sh file to transfer the .grype.yml file to repos created with the template

## Context for reviewers

Tested by running grype locally on database image and application image with and without the .grype.yml file to make sure it was loading and formatted correctly. 

## Testing

Install and run Grype locally with and without the .grype.yml file ignore to confirm it is working as intended.