### PR TITLE
Update Rubocop settings

### DIFF
--- a/app-rails/.rubocop.yml
+++ b/app-rails/.rubocop.yml
@@ -4,5 +4,5 @@ inherit_gem:
   pundit: config/rubocop-rspec.yml
   rubocop-rails-omakase: rubocop.yml
 AllCops:
-  Exclude:
-    - lib/templates/**/*
+  TargetRubyVersion: 3.3.1
+


### PR DESCRIPTION
## Ticket

- Resolves #8 
- Resolves #9
- Resolves #10 

## Changes

> Update Rubocop config to target specific Ruby version (should help narrow down a couple of style rules)
> Remove exclusion for directory that does not exist in this template

## Context for reviewers

> Read Rubocop docs, could not find any other configuration that we would need for this template
> Already have configuration for both Rails and rspec with no overrides currently (rubocop-rails-omakase, rubocop-rspec)


## Testing

> Ran linter, no issues found