### PR TITLE
Add database migration to enable pgcrypto

### DIFF
--- a/app-rails/db/migrate/20240613000011_enable_extension_for_uuid.rb
+++ b/app-rails/db/migrate/20240613000011_enable_extension_for_uuid.rb
@@ -1,0 +1,9 @@
+class EnableExtensionForUuid < ActiveRecord::Migration[7.1]
+  def up
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+
+  def down
+    disable_extension 'pgcrypto' if extension_enabled?('pgcrypto')
+  end
+end

--- a/app-rails/db/schema.rb
+++ b/app-rails/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_213056) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_13_000011) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Ticket

- N/A

## Changes

> What was added, updated, or removed in this PR.

- Add database migration to enable `pgcrypto` postgresql extension

## Context for reviewers

> Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

Using UUIDs with Postgresql [requires the Postgresql extension `pgcrypto`](https://guides.rubyonrails.org/active_record_postgresql.html#uuid-primary-keys) to generate random UUIDs. This PR adds a database migration to enable the extension.

Note: Depending on deployment and hosting, this may be an extension that requires elevated privileges to enable. That's the case when deploying with AWS. I will be noting that in the forthcoming PR documenting integration with the [Nava Platform infrastructure template](https://github.com/navapbc/template-infra).

## Testing

> Provide testing instructions and evidence that the code works as expected. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Before the migration:
<img width="481" alt="CleanShot 2024-06-12 at 17 12 15@2x" src="https://github.com/navapbc/template-application-rails/assets/67701/a31a3026-adaa-4782-88e3-4bfd134e776c">

After the migration:
<img width="466" alt="CleanShot 2024-06-12 at 17 12 29@2x" src="https://github.com/navapbc/template-application-rails/assets/67701/4ab1df3d-c550-411b-a671-35ba97ea4a36">

After rollback:
<img width="459" alt="CleanShot 2024-06-12 at 17 12 52@2x" src="https://github.com/navapbc/template-application-rails/assets/67701/56d04336-5375-4064-a192-b19914da9c69">
