### PR TITLE
added multiline validation and updated security doc

### DIFF
--- a/app-rails/app/forms/users/forgot_password_form.rb
+++ b/app-rails/app/forms/users/forgot_password_form.rb
@@ -3,5 +3,5 @@ class Users::ForgotPasswordForm
 
   attr_accessor :email
 
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }
 end

--- a/app-rails/app/forms/users/new_session_form.rb
+++ b/app-rails/app/forms/users/new_session_form.rb
@@ -6,5 +6,5 @@ class Users::NewSessionForm
   attr_accessor :email, :password
 
   validates :email, :password, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }, if: -> { email.present? }
 end

--- a/app-rails/app/forms/users/registration_form.rb
+++ b/app-rails/app/forms/users/registration_form.rb
@@ -6,7 +6,7 @@ class Users::RegistrationForm
   attr_accessor :email, :password, :password_confirmation, :role
 
   validates :email, :password, :role, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }, if: -> { email.present? }
 
   validates :password, confirmation: true, if: -> { password.present? }
 end

--- a/app-rails/app/forms/users/resend_verification_form.rb
+++ b/app-rails/app/forms/users/resend_verification_form.rb
@@ -5,5 +5,5 @@ class Users::ResendVerificationForm
 
   attr_accessor :email
 
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }
 end

--- a/app-rails/app/forms/users/reset_password_form.rb
+++ b/app-rails/app/forms/users/reset_password_form.rb
@@ -6,6 +6,6 @@ class Users::ResetPasswordForm
   attr_accessor :email, :password, :code
 
   validates :email, :password, :code, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }, if: -> { email.present? }
   validates :code, length: { is: 6 }, if: -> { code.present? }
 end

--- a/app-rails/app/forms/users/update_email_form.rb
+++ b/app-rails/app/forms/users/update_email_form.rb
@@ -5,5 +5,5 @@ class Users::UpdateEmailForm
 
   attr_accessor :email
 
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }
 end

--- a/app-rails/app/forms/users/verify_account_form.rb
+++ b/app-rails/app/forms/users/verify_account_form.rb
@@ -6,6 +6,6 @@ class Users::VerifyAccountForm
   attr_accessor :email, :code
 
   validates :email, :code, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, multiline: true }, if: -> { email.present? }
   validates :code, length: { is: 6 }, if: -> { code.present? }
 end

--- a/docs/app-rails/application-security.md
+++ b/docs/app-rails/application-security.md
@@ -55,7 +55,7 @@ There is currently no file upload or download functionality at this time, so ple
 - [x] Filter log entries so they do not include passwords or secrets
     - Note:  Log filtering is set in  [filter_parameter_logging.rb](app-rails/config/initializers/filter_parameter_logging.rb): `:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn`.
 - [x] Use the correct Ruby REGEX: `\A` and `\z` and not the more common: `/^` and `$/`.
-- [ ] Add `multiline: true` to regex `format:` in validations.
+- [x] Add `multiline: true` to regex `format:` in validations.
 - [x] When searching for data belonging to the user, search using Active Record from the user and not from the target data object. ie. Instead of doing: `@task = Task.find(params[:id])`, instead do: `@user.tasks.find(params[:id])`. 
     - Note: This application is also using [pundit](https://github.com/varvet/pundit) to support resource authorization.
 


### PR DESCRIPTION
## Ticket

- Resolves #37 

## Changes

- Added `multiline: true` to the format validations
- Updated security doc to show that this has been done throughout the app

## Context for reviewers
 
- While there isn't much of a difference in how the application handles invalid characters since we're using ruby appropriate regex, this is considered a security best practice, despite being redundant. 

## Testing

Test like a hacker! in the forgot password form, open the element in the browser and change the email input in the form from an `input` tag to a `textarea` tag, and change the input `type` from `email` to `text`. Now you can enter all the malformed, multiline, text/code you want. And confirm the server still rejects the invalid email addresses.