### PR TITLE
Fail CI on lint check

### DIFF
--- a/.github/workflows/ci-app-rails.yml
+++ b/.github/workflows/ci-app-rails.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           touch ./app-rails/.env
 
-      - run: make lint
+      - run: make lint-ci
       
   test:
     name: Test

--- a/app-rails/config/environments/development.rb
+++ b/app-rails/config/environments/development.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Allow web_console to render when triggered from the rails app running locally in a docker container.
-  config.web_console.permissions = ["192.168.0.0/16", "172.16.0.0/16", "10.0.0.0/8"]
+  config.web_console.permissions = [ "192.168.0.0/16", "172.16.0.0/16", "10.0.0.0/8" ]
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/app-rails/config/environments/production.rb
+++ b/app-rails/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # Exclude healthcheck endpoint from force SSL since healthchecks should not go through
   # the reverse proxy.
   # See https://api.rubyonrails.org/classes/ActionDispatch/SSL.html
-  config.ssl_options = { redirect: { exclude: -> request { /health/.match?(request.path) } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { /health/.match?(request.path) } } }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
## Ticket

- Resolves #44 

## Changes

- Update CI workflow to fail if offenses are detected by the linter.

## Context for reviewers

This should fail the first check as there are offenses in the repo. Once I've confirmed this is working as expected, I'll correct them in another commit.

## Testing

- failed CI run since there are known lint errors
- running linting locally shows no more errors (once that commit is added)