### PR TITLE
Honeypot fields and logic

### DIFF
--- a/app-rails/app/controllers/users/passwords_controller.rb
+++ b/app-rails/app/controllers/users/passwords_controller.rb
@@ -9,7 +9,8 @@ class Users::PasswordsController < ApplicationController
 
   def send_reset_password_instructions
     email = params[:users_forgot_password_form][:email]
-    @form = Users::ForgotPasswordForm.new(email: email)
+    hp_field = params[:users_forgot_password_form][:hp_field]
+    @form = Users::ForgotPasswordForm.new(email: email, hp_field: hp_field)
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
@@ -38,7 +39,7 @@ class Users::PasswordsController < ApplicationController
       return render :reset, status: :unprocessable_entity
     end
 
-    begin
+    begin 
       auth_service.confirm_forgot_password(
         @form.email,
         @form.code,

--- a/app-rails/app/controllers/users/passwords_controller.rb
+++ b/app-rails/app/controllers/users/passwords_controller.rb
@@ -39,7 +39,7 @@ class Users::PasswordsController < ApplicationController
       return render :reset, status: :unprocessable_entity
     end
 
-    begin 
+    begin
       auth_service.confirm_forgot_password(
         @form.email,
         @form.code,

--- a/app-rails/app/controllers/users/passwords_controller.rb
+++ b/app-rails/app/controllers/users/passwords_controller.rb
@@ -9,8 +9,8 @@ class Users::PasswordsController < ApplicationController
 
   def send_reset_password_instructions
     email = params[:users_forgot_password_form][:email]
-    hp_field = params[:users_forgot_password_form][:hp_field]
-    @form = Users::ForgotPasswordForm.new(email: email, hp_field: hp_field)
+    spam_trap = params[:users_forgot_password_form][:spam_trap]
+    @form = Users::ForgotPasswordForm.new(email: email, spam_trap: spam_trap)
 
     if @form.invalid?
       flash.now[:errors] = @form.errors.full_messages
@@ -60,6 +60,6 @@ class Users::PasswordsController < ApplicationController
     end
 
     def reset_password_params
-      params.require(:users_reset_password_form).permit(:email, :code, :password, :hp_field)
+      params.require(:users_reset_password_form).permit(:email, :code, :password, :spam_trap)
     end
 end

--- a/app-rails/app/controllers/users/passwords_controller.rb
+++ b/app-rails/app/controllers/users/passwords_controller.rb
@@ -60,6 +60,6 @@ class Users::PasswordsController < ApplicationController
     end
 
     def reset_password_params
-      params.require(:users_reset_password_form).permit(:email, :code, :password)
+      params.require(:users_reset_password_form).permit(:email, :code, :password, :hp_field)
     end
 end

--- a/app-rails/app/controllers/users/registrations_controller.rb
+++ b/app-rails/app/controllers/users/registrations_controller.rb
@@ -77,7 +77,7 @@ class Users::RegistrationsController < ApplicationController
     end
 
     def registration_params
-      params.require(:users_registration_form).permit(:email, :password, :password_confirmation, :role, :hp_field)
+      params.require(:users_registration_form).permit(:email, :password, :password_confirmation, :role, :spam_trap)
     end
 
     def verify_account_params

--- a/app-rails/app/controllers/users/registrations_controller.rb
+++ b/app-rails/app/controllers/users/registrations_controller.rb
@@ -77,7 +77,7 @@ class Users::RegistrationsController < ApplicationController
     end
 
     def registration_params
-      params.require(:users_registration_form).permit(:email, :password, :password_confirmation, :role)
+      params.require(:users_registration_form).permit(:email, :password, :password_confirmation, :role, :hp_field)
     end
 
     def verify_account_params

--- a/app-rails/app/controllers/users/sessions_controller.rb
+++ b/app-rails/app/controllers/users/sessions_controller.rb
@@ -94,7 +94,7 @@ class Users::SessionsController < Devise::SessionsController
     def new_session_params
       # If :users_new_session_form is renamed, make sure to also update it in
       # cognito_authenticatable.rb otherwise login will not work.
-      params.require(:users_new_session_form).permit(:email, :password)
+      params.require(:users_new_session_form).permit(:email, :password, :hp_field)
     end
 
     # This is similar to the default Devise SessionController implementation

--- a/app-rails/app/controllers/users/sessions_controller.rb
+++ b/app-rails/app/controllers/users/sessions_controller.rb
@@ -94,7 +94,7 @@ class Users::SessionsController < Devise::SessionsController
     def new_session_params
       # If :users_new_session_form is renamed, make sure to also update it in
       # cognito_authenticatable.rb otherwise login will not work.
-      params.require(:users_new_session_form).permit(:email, :password, :hp_field)
+      params.require(:users_new_session_form).permit(:email, :password, :spam_trap)
     end
 
     # This is similar to the default Devise SessionController implementation

--- a/app-rails/app/forms/users/forgot_password_form.rb
+++ b/app-rails/app/forms/users/forgot_password_form.rb
@@ -1,7 +1,9 @@
 class Users::ForgotPasswordForm
   include ActiveModel::Model
 
-  attr_accessor :email
+  attr_accessor :email, :hp_field
 
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  validates :hp_field, absence: true
 end

--- a/app-rails/app/forms/users/forgot_password_form.rb
+++ b/app-rails/app/forms/users/forgot_password_form.rb
@@ -1,9 +1,9 @@
 class Users::ForgotPasswordForm
   include ActiveModel::Model
 
-  attr_accessor :email, :hp_field
+  attr_accessor :email, :spam_trap
 
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
-  validates :hp_field, absence: true
+  validates :spam_trap, absence: true
 end

--- a/app-rails/app/forms/users/new_session_form.rb
+++ b/app-rails/app/forms/users/new_session_form.rb
@@ -3,10 +3,10 @@
 class Users::NewSessionForm
   include ActiveModel::Model
 
-  attr_accessor :email, :password, :hp_field
+  attr_accessor :email, :password, :spam_trap
 
   validates :email, :password, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
 
-  validates :hp_field, absence: true
+  validates :spam_trap, absence: true
 end

--- a/app-rails/app/forms/users/new_session_form.rb
+++ b/app-rails/app/forms/users/new_session_form.rb
@@ -3,8 +3,10 @@
 class Users::NewSessionForm
   include ActiveModel::Model
 
-  attr_accessor :email, :password
+  attr_accessor :email, :password, :hp_field
 
   validates :email, :password, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+
+  validates :hp_field, absence: true
 end

--- a/app-rails/app/forms/users/registration_form.rb
+++ b/app-rails/app/forms/users/registration_form.rb
@@ -3,12 +3,12 @@
 class Users::RegistrationForm
   include ActiveModel::Model
 
-  attr_accessor :email, :password, :password_confirmation, :role, :hp_field
+  attr_accessor :email, :password, :password_confirmation, :role, :spam_trap
 
   validates :email, :password, :role, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
 
   validates :password, confirmation: true, if: -> { password.present? }
 
-  validates :hp_field, absence: true
+  validates :spam_trap, absence: true
 end

--- a/app-rails/app/forms/users/registration_form.rb
+++ b/app-rails/app/forms/users/registration_form.rb
@@ -3,10 +3,12 @@
 class Users::RegistrationForm
   include ActiveModel::Model
 
-  attr_accessor :email, :password, :password_confirmation, :role
+  attr_accessor :email, :password, :password_confirmation, :role, :hp_field
 
   validates :email, :password, :role, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
 
   validates :password, confirmation: true, if: -> { password.present? }
+
+  validates :hp_field, absence: true
 end

--- a/app-rails/app/forms/users/reset_password_form.rb
+++ b/app-rails/app/forms/users/reset_password_form.rb
@@ -3,9 +3,11 @@
 class Users::ResetPasswordForm
   include ActiveModel::Model
 
-  attr_accessor :email, :password, :code
+  attr_accessor :email, :password, :code, :hp_field
 
   validates :email, :password, :code, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
   validates :code, length: { is: 6 }, if: -> { code.present? }
+
+  validates :hp_field, absence: true
 end

--- a/app-rails/app/forms/users/reset_password_form.rb
+++ b/app-rails/app/forms/users/reset_password_form.rb
@@ -3,11 +3,11 @@
 class Users::ResetPasswordForm
   include ActiveModel::Model
 
-  attr_accessor :email, :password, :code, :hp_field
+  attr_accessor :email, :password, :code, :spam_trap
 
   validates :email, :password, :code, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
   validates :code, length: { is: 6 }, if: -> { code.present? }
 
-  validates :hp_field, absence: true
+  validates :spam_trap, absence: true
 end

--- a/app-rails/app/helpers/uswds_form_builder.rb
+++ b/app-rails/app/helpers/uswds_form_builder.rb
@@ -79,12 +79,12 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def honeypot_field
-    hp_classes = "opacity-0 position-absolute z-bottom top-0 left-0 height-0 width-0"
+    spam_trap_classes = "opacity-0 position-absolute z-bottom top-0 left-0 height-0 width-0"
     label_text = "Do not fill in this field. It is an anti-spam measure."
 
-    @template.content_tag(:div, class: "usa-form-group #{hp_classes}") do
-      label(:hp_field, label_text, { tabindex: -1, class: "usa-label #{hp_classes}" }) +
-      @template.text_field(@object_name, :hp_field, { autocomplete: "false", tabindex: -1, class: "usa-input #{hp_classes}" })
+    @template.content_tag(:div, class: "usa-form-group #{spam_trap_classes}") do
+      label(:spam_trap, label_text, { tabindex: -1, class: "usa-label #{spam_trap_classes}" }) +
+      @template.text_field(@object_name, :spam_trap, { autocomplete: "false", tabindex: -1, class: "usa-input #{spam_trap_classes}" })
     end
   end
 

--- a/app-rails/app/helpers/uswds_form_builder.rb
+++ b/app-rails/app/helpers/uswds_form_builder.rb
@@ -78,6 +78,16 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     super(value, options)
   end
 
+  def honeypot_field()
+    hp_classes = "opacity-0 position-absolute z-bottom top-0 left-0 height-0 width-0"
+    label_text = "Do not fill in this field. It is an anti-spam measure."
+    
+    @template.content_tag(:div, class: "usa-form-group #{hp_classes}") do
+      label(:hp_field, label_text, { tabindex: -1, class: "usa-label #{hp_classes}" }) +
+      @template.text_field(@object_name, :hp_field, { autocomplete: "false", tabindex: -1, class: "usa-input #{hp_classes}", value: "test"})
+    end
+  end
+
   ########################################
   # Custom helpers
   ########################################

--- a/app-rails/app/helpers/uswds_form_builder.rb
+++ b/app-rails/app/helpers/uswds_form_builder.rb
@@ -78,13 +78,13 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     super(value, options)
   end
 
-  def honeypot_field()
+  def honeypot_field
     hp_classes = "opacity-0 position-absolute z-bottom top-0 left-0 height-0 width-0"
     label_text = "Do not fill in this field. It is an anti-spam measure."
-    
+
     @template.content_tag(:div, class: "usa-form-group #{hp_classes}") do
       label(:hp_field, label_text, { tabindex: -1, class: "usa-label #{hp_classes}" }) +
-      @template.text_field(@object_name, :hp_field, { autocomplete: "false", tabindex: -1, class: "usa-input #{hp_classes}", value: "test"}) # remove value: "test when done testing"
+      @template.text_field(@object_name, :hp_field, { autocomplete: "false", tabindex: -1, class: "usa-input #{hp_classes}" })
     end
   end
 

--- a/app-rails/app/helpers/uswds_form_builder.rb
+++ b/app-rails/app/helpers/uswds_form_builder.rb
@@ -84,7 +84,7 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     
     @template.content_tag(:div, class: "usa-form-group #{hp_classes}") do
       label(:hp_field, label_text, { tabindex: -1, class: "usa-label #{hp_classes}" }) +
-      @template.text_field(@object_name, :hp_field, { autocomplete: "false", tabindex: -1, class: "usa-input #{hp_classes}", value: "test"})
+      @template.text_field(@object_name, :hp_field, { autocomplete: "false", tabindex: -1, class: "usa-input #{hp_classes}", value: "test"}) # remove value: "test when done testing"
     end
   end
 

--- a/app-rails/app/views/users/passwords/forgot.html.erb
+++ b/app-rails/app/views/users/passwords/forgot.html.erb
@@ -5,6 +5,7 @@
 
 <%= us_form_with model: @form, url: users_forgot_password_path, local: true do |f| %>
   <%= f.email_field :email, { autocomplete: "username" } %>
+  <%= f.honeypot_field %>
 
   <%= f.submit t(".submit") %>
 <% end %>

--- a/app-rails/app/views/users/passwords/reset.html.erb
+++ b/app-rails/app/views/users/passwords/reset.html.erb
@@ -12,6 +12,7 @@
 <h1><%= t(".title") %></h1>
 
 <%= us_form_with model: @form, url: users_reset_password_path, local: true do |f| %>
+  <%= f.honeypot_field %>
   <%= f.text_field :code, { autocomplete: "off", label: t('.code'), width: "md" } %>
 
   <%= f.email_field :email, { autocomplete: "username" } %>

--- a/app-rails/app/views/users/registrations/new.html.erb
+++ b/app-rails/app/views/users/registrations/new.html.erb
@@ -13,6 +13,7 @@
 
   <%= us_form_with model: @form, url: users_registrations_path, local: true do |f| %>
     <%= f.hidden_field :role %>
+    <%= f.honeypot_field %>
     <%= f.email_field :email %>
 
     <%= f.password_field :password, autocomplete: "new-password", id: "new-password", hint: t("users.password_hint") %>

--- a/app-rails/app/views/users/sessions/new.html.erb
+++ b/app-rails/app/views/users/sessions/new.html.erb
@@ -6,6 +6,7 @@
   </h1>
 
   <%= us_form_with model: @form, url: new_user_session_path, local: true do |f| %>
+    <%= f.honeypot_field %>
     <%= f.email_field :email, { autocomplete: "username" } %>
 
     <%= f.password_field :password, {id: "password", autocomplete: "current-password"} %>

--- a/app-rails/config/locales/defaults/en.yml
+++ b/app-rails/config/locales/defaults/en.yml
@@ -48,7 +48,7 @@ en:
       long: "%B %d, %Y"
   errors:
     attributes:
-      hp_field:
+      spam_trap:
         present: "This field should be left empty. It is intended to prevent bots from submitting spam using this form."
   helpers:
     submit:

--- a/app-rails/config/locales/defaults/en.yml
+++ b/app-rails/config/locales/defaults/en.yml
@@ -49,7 +49,7 @@ en:
   errors:
     attributes:
       hp_field:
-        present: "You entered text in a field that is meant to catch spambots."
+        present: "This field should be left empty. It is intended to prevent bots from submitting spam using this form."
   helpers:
     submit:
       create: "Submit"

--- a/app-rails/config/locales/defaults/en.yml
+++ b/app-rails/config/locales/defaults/en.yml
@@ -46,6 +46,10 @@ en:
       default: "%m/%d/%Y"
       short: "%b %d"
       long: "%B %d, %Y"
+  errors:
+    attributes:
+      hp_field:
+        present: "You entered text in a field that is meant to catch spambots."
   helpers:
     submit:
       create: "Submit"

--- a/app-rails/spec/controllers/users/passwords_controller_spec.rb
+++ b/app-rails/spec/controllers/users/passwords_controller_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Users::PasswordsController do
 
       expect(response.status).to eq(422)
     end
+
+    it "handles submission by bots" do
+      post :send_reset_password_instructions, params: {
+        users_forgot_password_form: { email: "UsernameExists@example.com", hp_field: "I am a bot" },
+        locale: "en"
+      }
+
+      expect(response.status).to eq(422)
+    end
   end
 
   describe "GET reset" do
@@ -89,6 +98,20 @@ RSpec.describe Users::PasswordsController do
           email: "test@example.com",
           code: "000001",
           password: "password"
+        },
+        locale: "en"
+      }
+
+      expect(response.status).to eq(422)
+    end
+
+    it "handles submission by bots" do 
+      post :confirm_reset, params: {
+        users_reset_password_form: {
+          email: "test@example.com",
+          code: "123456",
+          password: "password",
+          hp_field: "I am a bot"
         },
         locale: "en"
       }

--- a/app-rails/spec/controllers/users/passwords_controller_spec.rb
+++ b/app-rails/spec/controllers/users/passwords_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Users::PasswordsController do
 
     it "handles submission by bots" do
       post :send_reset_password_instructions, params: {
-        users_forgot_password_form: { email: "UsernameExists@example.com", hp_field: "I am a bot" },
+        users_forgot_password_form: { email: "UsernameExists@example.com", spam_trap: "I am a bot" },
         locale: "en"
       }
 
@@ -111,7 +111,7 @@ RSpec.describe Users::PasswordsController do
           email: "test@example.com",
           code: "123456",
           password: "password",
-          hp_field: "I am a bot"
+          spam_trap: "I am a bot"
         },
         locale: "en"
       }

--- a/app-rails/spec/controllers/users/passwords_controller_spec.rb
+++ b/app-rails/spec/controllers/users/passwords_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Users::PasswordsController do
       expect(response.status).to eq(422)
     end
 
-    it "handles submission by bots" do 
+    it "handles submission by bots" do
       post :confirm_reset, params: {
         users_reset_password_form: {
           email: "test@example.com",

--- a/app-rails/spec/controllers/users/registrations_controller_spec.rb
+++ b/app-rails/spec/controllers/users/registrations_controller_spec.rb
@@ -71,6 +71,22 @@ RSpec.describe Users::RegistrationsController do
 
       expect(response.status).to eq(422)
     end
+
+    it "handles submission by bots" do
+      email = "test@example.com"
+
+      post :create, params: {
+        users_registration_form: {
+          email: email,
+          password: "password",
+          role: "employer",
+          hp_field: "I am a bot"
+        },
+        locale: "en"
+      }
+
+      expect(response.status).to eq(422)
+    end
   end
 
   describe "GET new_account_verification" do

--- a/app-rails/spec/controllers/users/registrations_controller_spec.rb
+++ b/app-rails/spec/controllers/users/registrations_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Users::RegistrationsController do
           email: email,
           password: "password",
           role: "employer",
-          hp_field: "I am a bot"
+          spam_trap: "I am a bot"
         },
         locale: "en"
       }

--- a/app-rails/spec/controllers/users/sessions_controller_spec.rb
+++ b/app-rails/spec/controllers/users/sessions_controller_spec.rb
@@ -91,6 +91,21 @@ RSpec.describe Users::SessionsController do
       expect(session[:challenge_email]).to eq("mfa@example.com")
       expect(response).to redirect_to(session_challenge_path)
     end
+
+    it "handles submission by bots" do
+      create(:user, uid: uid)
+
+      post :create, params: {
+        users_new_session_form: {
+          email: "test@example.com",
+          password: "password",
+          hp_field: "I am a bot"
+        },
+        locale: "en"
+      }
+
+      expect(response.status).to eq(422)
+    end
   end
 
   describe "GET challenge" do

--- a/app-rails/spec/controllers/users/sessions_controller_spec.rb
+++ b/app-rails/spec/controllers/users/sessions_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Users::SessionsController do
         users_new_session_form: {
           email: "test@example.com",
           password: "password",
-          hp_field: "I am a bot"
+          spam_trap: "I am a bot"
         },
         locale: "en"
       }

--- a/app-rails/spec/forms/users/new_session_form_spec.rb
+++ b/app-rails/spec/forms/users/new_session_form_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe Users::NewSessionForm do
     form = Users::NewSessionForm.new(
       email: "test@example.com",
       password: "password",
-      hp_field: "I am a bot"
+      spam_trap: "I am a bot"
     )
 
     expect(form).not_to be_valid
-    expect(form.errors.of_kind?(:hp_field, :present)).to be_truthy
+    expect(form.errors.of_kind?(:spam_trap, :present)).to be_truthy
   end
 end

--- a/app-rails/spec/forms/users/new_session_form_spec.rb
+++ b/app-rails/spec/forms/users/new_session_form_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe Users::NewSessionForm do
     expect(form).not_to be_valid
     expect(form.errors.of_kind?(:email, :invalid)).to be_truthy
   end
+
+  it "requires the honeypot field is empty" do
+    form = Users::NewSessionForm.new(
+      email: "test@example.com",
+      password: "password",
+      hp_field: "I am a bot"
+    )
+
+    expect(form).not_to be_valid
+    expect(form.errors.of_kind?(:hp_field, :present)).to be_truthy
+  end
 end

--- a/app-rails/spec/forms/users/new_session_form_spec.rb
+++ b/app-rails/spec/forms/users/new_session_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Users::NewSessionForm do
     expect(form.errors.of_kind?(:email, :invalid)).to be_truthy
   end
 
-  it "requires the honeypot field is empty" do
+  it "requires the honeypot field to be empty" do
     form = Users::NewSessionForm.new(
       email: "test@example.com",
       password: "password",

--- a/app-rails/spec/forms/users/registration_form_spec.rb
+++ b/app-rails/spec/forms/users/registration_form_spec.rb
@@ -36,4 +36,13 @@ RSpec.describe Users::RegistrationForm do
     expect(form).not_to be_valid
     expect(form.errors.of_kind?(:email, :invalid)).to be_truthy
   end
+
+  it "requires the honeypot field is empty" do
+    form.email = "test@example.com"
+    form.password = valid_password
+    form.hp_field = "I am a bot"
+
+    expect(form).not_to be_valid
+    expect(form.errors.of_kind?(:hp_field, :present)).to be_truthy
+  end
 end

--- a/app-rails/spec/forms/users/registration_form_spec.rb
+++ b/app-rails/spec/forms/users/registration_form_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Users::RegistrationForm do
   it "requires the honeypot field is empty" do
     form.email = "test@example.com"
     form.password = valid_password
-    form.hp_field = "I am a bot"
+    form.spam_trap = "I am a bot"
 
     expect(form).not_to be_valid
-    expect(form.errors.of_kind?(:hp_field, :present)).to be_truthy
+    expect(form.errors.of_kind?(:spam_trap, :present)).to be_truthy
   end
 end

--- a/docs/app-rails/application-security.md
+++ b/docs/app-rails/application-security.md
@@ -49,7 +49,7 @@ There is currently no file upload or download functionality at this time, so ple
 - [x] Use a secondary verification when users change their password
     - Note: Change password requires 6 digit code from email sent to user's email address.
 - [ ] Require user's password when changing email.
-- [ ] Include honeypot fields and logic on Non logged in forms to catch bots that spam all fields (good resource: https://nedbatchelder.com/text/stopbots.html).
+- [x] Include honeypot fields and logic on Non logged in forms to catch bots that spam all fields (good resource: https://nedbatchelder.com/text/stopbots.html).
 - [ ] Consider using Captcha on account creation, login, change password, and change email forms.
     - Note: Captchas are often not accessible to screen readers and their use should be part of a UX discussion.
 - [x] Filter log entries so they do not include passwords or secrets


### PR DESCRIPTION
## Ticket

- Resolves #35 

## Changes

- Added honeypot field to uswds forms helper
- Added custom honeypot field error message
- Added honeypot validations to form models
- Added honeypot field to controllers
- Added honeypot to publicly accessible forms:
  - sign in
  - create account
  - forgot password
  - reset password
- Added tests
- Updated security doc

## Context for reviewers

Added honeypot fields to publicly accessible forms to combat spam bots, following guidance from the [rails security best practices doc
](https://guides.rubyonrails.org/security.html#captchas).

## Testing

- Run tests
- Tab through the pages and confirm the honeypot fields aren't focused (Ideally with a screen reader)
- Submit fields normally and confirm normal behavior
- Edit the hp_field's value to confirm the form fails to submit