### PR TITLE
Update healthcheck route SSL exclusion to specifically `GET /health`

### DIFF
--- a/app-rails/config/environments/production.rb
+++ b/app-rails/config/environments/production.rb
@@ -54,10 +54,12 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Exclude healthcheck endpoint from force SSL since healthchecks should not go through
-  # the reverse proxy.
+  # Exclude healthcheck endpoint from force SSL since healthcheck requests can
+  # come from internal network sources (e.g., a load balancer) that do not go
+  # through the service's SSL-terminating reverse proxy.
+  #
   # See https://api.rubyonrails.org/classes/ActionDispatch/SSL.html
-  config.ssl_options = { redirect: { exclude: ->(request) { /health/.match?(request.path) } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.get? and request.path == "/health" } } }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
Instead of any route that might have "health" in its name (e.g.
`/patient/123/super-sensitive-health-records`).

## Testing

https://github.com/navapbc/pfml-starter-kit-app/commit/ab6f7e3c52ecaa85d803e066da18e1d038cfa03c

![image](https://github.com/user-attachments/assets/4012aaee-1d80-4bc6-99a6-fa892207cddc)

![image](https://github.com/user-attachments/assets/2f2bde75-7611-449f-8190-144d908bbf34)
