### PR TITLE
Remove aws-cli from production image

### DIFF
--- a/template/{{app_name}}/Dockerfile.jinja
+++ b/template/{{app_name}}/Dockerfile.jinja
@@ -113,16 +113,8 @@ RUN apt-get update -qq \
         curl \
         libvips \
         postgresql-client \
-        python-is-python3 \
-        python3-venv \
-        unzip \
-        wget \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" \
-    && unzip awscli-bundle.zip \
-    && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
-    && rm -rf ./awscli-bundle awscli-bundle.zip
+    && rm -rf /var/lib/apt/lists/*
 
 # Install custom db migrate script
 COPY bin/db-migrate /usr/bin/


### PR DESCRIPTION
## Changes

This is been removed for a while now in some downstream applications[1], mainly to fix vulnerability warnings, but also we shouldn't ship things to production that aren't actually required at runtime (particularly when not verifying the install and pulling in a bunch of unrelated dependencies).

[1] https://github.com/navapbc/pfml-starter-kit-app/commit/6b61c6448ef18fda7040f4123a3c9074f3d8c588

## Testing

https://github.com/navapbc/platform-test/pull/170