### PR TITLE
Support a read-only root container filesystem

### DIFF
--- a/template-only-docs/Deployment.md
+++ b/template-only-docs/Deployment.md
@@ -22,7 +22,13 @@ While following the [infrastructure template installation instructions](https://
 1. In `/infra/<APP_NAME>/app-config/<ENVIRONMENT>.tf`:
     1. Set the `domain_name`.
     2. Set `enable_https` to `true`.
-    3. Set `enable_command_execution` to `true`: This is necessary temporarily until a temporary file system can be enabled. Otherwise, ECS will run with read-only root filesystem, which will cause rails to error.
+1. In `/infra/<APP_NAME>/app-config/env-config/outputs.tf`:
+    1. Configure the service's `ephemeral_write_volumes`:
+        ```terraform
+        ephemeral_write_volumes = [
+          "/rails/tmp"
+        ]
+        ```
 1. In `/infra/<APP_NAME>/app-config/env-config/environment-variables.tf`:
     1. Add an entry to `secrets`:
     ```terraform

--- a/template/{{app_name}}/Dockerfile.jinja
+++ b/template/{{app_name}}/Dockerfile.jinja
@@ -20,6 +20,8 @@ ENV RAILS_ENV="production" \
 # Start the server by default, this can be overwritten at runtime
 EXPOSE {{ app_local_port }}
 
+# In production, this should be the only filesystem location with writes
+VOLUME /rails/tmp
 
 ##########################################################################################
 # BUILD: Throw-away build stage
@@ -73,6 +75,10 @@ RUN gem install debug -v 1.10.0
 
 # Copy application code
 COPY . .
+
+# During local development, app is configured to write to more places
+VOLUME /rails/log
+VOLUME /rails/storage
 
 CMD ["./bin/dev"]
 

--- a/template/{{app_name}}/docker-compose.mock-production.yml.jinja
+++ b/template/{{app_name}}/docker-compose.mock-production.yml.jinja
@@ -15,6 +15,8 @@ services:
   # Rails app
   # Configured for "production" RAILS_ENV
   {{app_name}}:
+    # the container root filesystem is read-only in production, so mirror that
+    read_only: true
     build:
       context: .
       target: release


### PR DESCRIPTION
## Ticket

Half of solving https://github.com/navapbc/template-application-rails/issues/58

## Changes

Declare writable locations with `VOLUME` instructions in the container build file so that bind mounts can be used in ECS to make those locations writable when deployed, with some configuration[1].

[1] https://github.com/navapbc/template-infra/commit/60934c7e40f598c0b4f737891d39d955a6c3eafc

## Testing

https://github.com/navapbc/platform-test/pull/175