### PR TITLE
update documentation link to warden

### DIFF
--- a/template/docs/{{app_name}}/auth.md
+++ b/template/docs/{{app_name}}/auth.md
@@ -7,7 +7,7 @@ Authentication is the process of verifying the credentials of a user. We use AWS
 - User credentials are stored in AWS Cognito
 - Password policy is enforced by Cognito
 - Custom pages are built for the AWS Cognito flows (login, signup, forgot password, etc.). We aren't using the hosted UI that Cognito provides since we need more control over the UI and content.
-- [Devise](https://www.rubydoc.info/github/heartcombo/devise/main) and [Warden](https://www.rubydoc.info/github/hassox/warden) facilitate auth and session management
+- [Devise](https://www.rubydoc.info/github/heartcombo/devise/main) and [Warden](https://github.com/wardencommunity/warden/wiki) facilitate auth and session management
 
 ## Authorization
 


### PR DESCRIPTION
## Ticket

n/a

## Changes

Updates a documentation link that no longer resolves.
https://www.rubydoc.info/github/hassox/warden gives a 404. The underlying https://github.com/hassox/warden redirects to https://github.com/wardencommunity/warden. Updated the documentation to use the latter's wiki (https://github.com/wardencommunity/warden/wiki)


## Testing

https://github.com/navapbc/platform-test/pull/196 (shows the CI check that flagged the broken link)