### PR TITLE
Remove sassc gem

### DIFF
--- a/template/{{app_name}}/Gemfile
+++ b/template/{{app_name}}/Gemfile
@@ -88,9 +88,6 @@ group :development do
   gem "rubocop-rails-omakase", require: false
   gem "rubocop-rspec", require: false
 
-  # Sass compiling
-  gem "sassc", "~> 2.4"
-
   # Test notifications locally without sending the emails
   gem "letter_opener"
 


### PR DESCRIPTION
## Ticket

- Resolves https://github.com/navapbc/template-application-rails/issues/87

## Changes

see title

## Context for reviewers

sassc is deprecated. Moving to dart-sass which is already in the repo

## Testing

see https://github.com/navapbc/platform-test/pull/200