### PR TITLE
Add enhancements for USDS form builder

### DIFF
--- a/template/{{app_name}}/app/helpers/uswds_form_builder.rb
+++ b/template/{{app_name}}/app/helpers/uswds_form_builder.rb
@@ -4,6 +4,8 @@
 # additional helpers like fieldset and hint.
 # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html
 class UswdsFormBuilder < ActionView::Helpers::FormBuilder
+  standard_helpers = %i[email_field file_field password_field text_area text_field]
+
   def initialize(*args)
     super
     self.options[:html] ||= {}
@@ -19,25 +21,33 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   #
   # Example usage:
   #   <%= f.text_field :foobar, { label: "Custom label text", hint: "Some hint text" } %>
-  %i[email_field file_field password_field text_area text_field].each do |field_type|
+  standard_helpers.each do |field_type|
     define_method(field_type) do |attribute, options = {}|
       classes = us_class_for_field_type(field_type, options[:width])
       classes += " usa-input--error" if has_error?(attribute)
-
-      options[:class] ||= ""
-      options[:class].prepend("#{classes} ")
+      append_to_option(options, :class, " #{classes}")
 
       label_text = options.delete(:label)
+      label_class = options.delete(:label_class) || ""
 
-      us_form_group(attribute: attribute) do
-        us_text_field_label(attribute, label_text, options) + super(attribute, options)
+      label_options = options.except(:width, :class, :id).merge({
+        class: label_class,
+        for: options[:id]
+      })
+      field_options = options.except(:label, :hint, :large_label, :label_class)
+
+      if options[:hint]
+        field_options[:aria_describedby] = hint_id(attribute)
+      end
+
+      form_group(attribute, options[:group_options] || {}) do
+        us_text_field_label(attribute, label_text, label_options) + super(attribute, field_options)
       end
     end
   end
 
   def check_box(attribute, options = {}, *args)
-    options[:class] ||= ""
-    options[:class].prepend(us_class_for_field_type(:check_box))
+    append_to_option(options, :class, " #{us_class_for_field_type(:check_box)}")
 
     label_text = options.delete(:label)
 
@@ -47,8 +57,7 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def radio_button(attribute, tag_value, options = {})
-    options[:class] ||= ""
-    options[:class].prepend(us_class_for_field_type(:radio_button))
+    append_to_option(options, :class, " #{us_class_for_field_type(:radio_button)}")
 
     label_text = options.delete(:label)
     label_options = { for: field_id(attribute, tag_value) }.merge(options)
@@ -59,21 +68,21 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(attribute, choices, options = {}, html_options = {})
-    classes = "usa-select"
-
-    html_options[:class] ||= ""
-    html_options[:class].prepend("#{classes} ")
+    append_to_option(html_options, :class, " usa-select")
 
     label_text = options.delete(:label)
 
-    us_form_group(attribute: attribute) do
+    form_group(attribute) do
       us_text_field_label(attribute, label_text, options) + super(attribute, choices, options, html_options)
     end
   end
 
   def submit(value = nil, options = {})
-    options[:class] ||= ""
-    options[:class].prepend("usa-button ")
+    append_to_option(options, :class, " usa-button")
+
+    if options[:big]
+      append_to_option(options, :class, " usa-button--big margin-y-6")
+    end
 
     super(value, options)
   end
@@ -92,16 +101,49 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   # Custom helpers
   ########################################
 
+  def tax_id_field(attribute, options = {})
+    options[:inputmode] = "numeric"
+    options[:placeholder] = "_________"
+    options[:width] = "md"
+
+    append_to_option(options, :class, " usa-masked")
+    append_to_option(options, :hint, @template.content_tag(:p, I18n.t("us_form_with.tax_id_format")))
+
+    text_field(attribute, options)
+  end
+
+  def date_picker(attribute, options = {})
+    raw_value = object.send(attribute) if object
+
+    append_to_option(options, :hint, @template.content_tag(:p, I18n.t("us_form_with.date_picker_format")))
+
+    group_options = options[:group_options] || {}
+    append_to_option(group_options, :class, " usa-date-picker")
+
+    if raw_value.is_a?(Date)
+      append_to_option(group_options, :"data-default-value", raw_value.strftime("%Y-%m-%d"))
+      value = raw_value.strftime("%m/%d/%Y") if raw_value.is_a?(Date)
+    end
+
+    text_field(attribute, options.merge(value: value, group_options: group_options))
+  end
+
   def field_error(attribute)
     return unless has_error?(attribute)
 
     @template.content_tag(:span, object.errors[attribute].to_sentence, class: "usa-error-message")
   end
 
-  def fieldset(legend, attribute = nil, &block)
-    us_form_group(attribute: attribute) do
+  def fieldset(legend, options = {}, &block)
+    legend_classes = "usa-legend"
+
+    if options[:large_legend]
+      legend_classes += " usa-legend--large"
+    end
+
+    form_group(options[:attribute]) do
       @template.content_tag(:fieldset, class: "usa-fieldset") do
-        @template.content_tag(:legend, legend, class: "usa-legend") + @template.capture(&block)
+        @template.content_tag(:legend, legend, class: legend_classes) + @template.capture(&block)
       end
     end
   end
@@ -121,6 +163,17 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     @template.content_tag(:div, @template.raw(text), class: "usa-hint")
   end
 
+  def form_group(attribute = nil, options = {}, &block)
+    append_to_option(options, :class, " usa-form-group")
+    children = @template.capture(&block)
+
+    if options[:show_error] or (attribute and has_error?(attribute))
+      append_to_option(options, :class, " usa-form-group--error")
+    end
+
+    @template.content_tag(:div, children, options)
+  end
+
   def yes_no(attribute, options = {})
     yes_options = options[:yes_options] || {}
     no_options = options[:no_options] || {}
@@ -132,7 +185,7 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
     @template.capture do
       # Hidden field included for same reason as radio button collections (https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_radio_buttons)
       hidden_field(attribute, value: "") +
-      fieldset(options[:legend] || human_name(attribute), attribute) do
+      fieldset(options[:legend] || human_name(attribute), { attribute: attribute }) do
         buttons =
           radio_button(attribute, true, yes_options) +
           radio_button(attribute, false, no_options)
@@ -147,6 +200,16 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   private
+    def append_to_option(options, key, value)
+      current_value = options[key] || ""
+
+      if current_value.is_a?(Proc)
+        options[key] = -> { current_value.call + value }
+      else
+        options[key] = current_value + value
+      end
+    end
+
     def us_class_for_field_type(field_type, width = nil)
       case field_type
       when :check_box
@@ -167,15 +230,33 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
 
     # Render the label, hint text, and error message for a form field
     def us_text_field_label(attribute, text = nil, options = {})
-      hint_text = options.delete(:hint)
+      hint_option = options.delete(:hint)
+      classes = "usa-label"
+      for_attr = options[:for] || field_id(attribute)
 
-      if hint_text
-        hint_id = "#{attribute}_hint"
-        options[:aria_describedby] = hint_id
-        hint = @template.content_tag(:div, @template.raw(hint_text), id: hint_id, class: "usa-hint")
+      if options[:class]
+        classes += " #{options[:class]}"
       end
 
-      label(attribute, text, { class: "usa-label" }) + hint + field_error(attribute)
+      unless text
+        text = human_name(attribute)
+      end
+
+      if options[:optional]
+        text += @template.content_tag(:span, " (#{I18n.t('us_form_with.optional').downcase})", class: "usa-hint")
+      end
+
+      if hint_option
+        if hint_option.is_a?(Proc)
+          hint_content = @template.capture(&hint_option)
+        else
+          hint_content = @template.raw(hint_option)
+        end
+
+        hint = @template.content_tag(:div, hint_content, id: hint_id(attribute), class: "usa-hint")
+      end
+
+      label(attribute, @template.raw(text), { class: classes, for: for_attr }) + field_error(attribute) + hint
     end
 
     # Label for a checkbox or radio
@@ -192,11 +273,7 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
       label(attribute, label_text, options)
     end
 
-    def us_form_group(attribute: nil, show_error: nil, &block)
-      children = @template.capture(&block)
-      classes = "usa-form-group"
-      classes += " usa-form-group--error" if show_error or (attribute and has_error?(attribute))
-
-      @template.content_tag(:div, children, class: classes)
+    def hint_id(attribute)
+      "#{attribute}_hint"
     end
 end

--- a/template/{{app_name}}/config/locales/defaults/en.yml
+++ b/template/{{app_name}}/config/locales/defaults/en.yml
@@ -61,3 +61,6 @@ en:
   us_form_with:
     boolean_true: "Yes"
     boolean_false: "No"
+    date_picker_format: "Format: mm/dd/yyyy"
+    optional: "Optional"
+    tax_id_format: "For example, 123456789"

--- a/template/{{app_name}}/spec/helpers/uswds_form_builder_spec.rb
+++ b/template/{{app_name}}/spec/helpers/uswds_form_builder_spec.rb
@@ -1,0 +1,277 @@
+require 'rails_helper'
+
+RSpec.describe UswdsFormBuilder do
+  before do
+    test_form_class = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :first_name, :string
+      attribute :start_date, :date  # for date_picker
+    end
+
+    stub_const("TestForm", test_form_class)
+  end
+
+
+  let(:template) { ActionView::Base.empty }
+  let(:object) { TestForm.new }
+  let(:builder) { described_class.new(:object, object, template, {}) }
+
+  describe '#text_field' do
+    let(:result) { builder.text_field(:first_name, label: 'Name') }
+
+    it 'outputs a text input' do
+      expect(result).to have_element(:input, type: 'text', class: 'usa-input', name: 'object[first_name]')
+      expect(result).not_to have_css('.usa-form-group--error')
+      expect(result).not_to have_css('.usa-error-message')
+    end
+
+    it 'outputs a label' do
+      expect(result).to have_element(:label, class: 'usa-label', for: 'object_first_name')
+    end
+
+    context 'with id option' do
+      let(:result) { builder.text_field(:first_name, id: 'custom-id') }
+
+      it 'outputs a label associated with the input with the custom id' do
+        expect(result).to have_element(:input, id: 'custom-id')
+        expect(result).to have_element(:label, for: 'custom-id')
+      end
+    end
+
+    context 'with label option' do
+      let(:result) { builder.text_field(:first_name, label: 'Custom label') }
+
+      it 'outputs a label' do
+        expect(result).to have_element(:label, text: 'Custom label', class: 'usa-label')
+      end
+    end
+
+    context 'with hint' do
+      let(:result) { builder.text_field(:first_name, hint: 'Enter your name') }
+
+      it 'outputs a hint' do
+        expect(result).to have_element(:div, text: 'Enter your name', class: 'usa-hint')
+      end
+
+      it 'adds aria-describedby to the input' do
+        expect(result).to have_element(:input, aria_describedby: 'first_name_hint')
+      end
+    end
+
+    context 'with errors' do
+      let(:result) { builder.text_field(:first_name) }
+
+      before do
+        object.errors.add(:first_name, 'is invalid')
+      end
+
+      it 'outputs an error message' do
+        expect(result).to have_element(:div, class: 'usa-form-group--error')
+        expect(result).to have_element(:span, text: 'is invalid', class: 'usa-error-message')
+      end
+    end
+
+    context 'with width' do
+      let(:result) { builder.text_field(:first_name, width: 'md') }
+
+      it 'adds a width class' do
+        expect(result).to have_element(:input, class: 'usa-input usa-input--md')
+      end
+    end
+
+    context 'with optional set to true' do
+      let(:result) { builder.text_field(:first_name, label: 'Name', optional: true) }
+
+      it 'outputs an optional label' do
+        expect(result).to have_element(:label, text: 'Name (optional)')
+      end
+    end
+
+    context 'with custom class' do
+      let(:result) { builder.text_field(:first_name, class: 'custom-class') }
+
+      it 'adds the class to the input' do
+        expect(result).to have_element(:input, class: 'custom-class usa-input')
+      end
+    end
+
+    context 'with label_class' do
+      let(:result) { builder.text_field(:first_name, label_class: 'custom-label-class') }
+
+      it 'adds the class to the label' do
+        expect(result).to have_element(:label, class: 'usa-label custom-label-class')
+      end
+    end
+  end
+
+  describe '#hint' do
+    let(:result) { builder.hint('Enter your name') }
+
+    it 'outputs a hint' do
+      expect(result).to have_element(:div, text: 'Enter your name', class: 'usa-hint')
+    end
+  end
+
+  describe '#date_picker' do
+    let(:result) { builder.date_picker(:start_date) }
+    let(:object) { TestForm.new(start_date: Date.new(2024, 1, 31)) }
+
+    it 'wraps the input with a date picker class' do
+      expect(result).to have_element(:div, class: 'usa-date-picker usa-form-group')
+    end
+
+    it 'includes example format in the hint' do
+      expect(result).to have_element(:p, text: "Format: mm/dd/yyyy")
+    end
+
+    it 'adds USWDS attributes for showing the current value' do
+      expect(result).to have_element(:input, value: '01/31/2024')
+      expect(result).to have_element(:div, class: 'usa-date-picker', "data-default-value": '2024-01-31')
+    end
+
+    context 'when no existing date value' do
+      let(:object) { TestForm.new(start_date: nil) }
+
+      it 'does not set a value' do
+        expect(result).to have_element(:input, value: nil)
+        expect(result).to have_element(:div, class: 'usa-date-picker', "data-default-value": nil)
+      end
+    end
+  end
+
+  describe '#fieldset' do
+    let(:result) { builder.fieldset('Legend') { 'Fieldset content' } }
+
+    it 'outputs a fieldset' do
+      expect(result).to have_element(:fieldset, class: 'usa-fieldset')
+    end
+
+    it 'outputs a legend' do
+      expect(result).to have_element(:legend, text: 'Legend', class: 'usa-legend')
+    end
+
+    it 'outputs the content within the block' do
+      expect(result).to have_text('Fieldset content')
+    end
+
+    context 'with large_legend set to true' do
+      let(:result) { builder.fieldset('Legend', large_legend: true) { 'Fieldset content' } }
+
+      it 'outputs a large legend' do
+        expect(result).to have_element(:legend, class: 'usa-legend usa-legend--large')
+      end
+    end
+  end
+
+  describe '#select' do
+    let(:result) { builder.select(:first_name, [ 'Option 1', 'Option 2' ]) }
+
+    it 'outputs a select field' do
+      expect(result).to have_element(:select, class: 'usa-select', name: 'object[first_name]')
+    end
+
+    context 'with label' do
+      let(:result) { builder.select(:first_name, [ 'Option 1', 'Option 2' ], label: 'Custom label') }
+
+      it 'outputs a label' do
+        expect(result).to have_element(:label, text: 'Custom label', class: 'usa-label')
+      end
+    end
+  end
+
+  describe '#submit' do
+    let (:result) { builder.submit() }
+
+    it 'outputs a submit button' do
+      expect(result).to have_element(:input, type: 'submit', class: 'usa-button')
+    end
+
+    context 'with big set to true' do
+      let (:result) { builder.submit(nil, { big: true }) }
+
+      it 'outputs a big submit button' do
+        expect(result).to have_element(:input, type: 'submit', class: 'usa-button--big')
+      end
+    end
+  end
+
+  describe '#check_box' do
+    let(:result) { builder.check_box(:first_name) }
+
+    it 'outputs a check box' do
+      expect(result).to have_element(:div, class: 'usa-checkbox')
+      expect(result).to have_element(:input, type: 'checkbox', class: 'usa-checkbox__input', name: 'object[first_name]')
+    end
+
+    context 'with hint' do
+      let(:result) { builder.check_box(:first_name, hint: 'Check this box') }
+
+      it 'outputs a hint' do
+        expect(result).to have_element(:span, text: 'Check this box', class: 'usa-checkbox__label-description')
+      end
+    end
+  end
+
+  describe '#radio_button' do
+    let(:result) { builder.radio_button(:first_name, 'yes') }
+
+    it 'outputs a radio button' do
+      expect(result).to have_element(:div, class: 'usa-radio')
+      expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input', name: 'object[first_name]', value: 'yes')
+    end
+
+    context 'with hint' do
+      let(:result) { builder.radio_button(:first_name, 'yes', hint: 'Select yes') }
+
+      it 'outputs a hint' do
+        expect(result).to have_element(:span, text: 'Select yes', class: 'usa-radio__label-description')
+      end
+    end
+  end
+
+  describe '#tax_id_field' do
+    let(:result) { builder.tax_id_field(:first_name) }
+
+    it 'outputs a text input' do
+      expect(result).to have_element(:input, type: 'text', class: 'usa-input', name: 'object[first_name]')
+      expect(result).not_to have_css('.usa-form-group--error')
+      expect(result).not_to have_css('.usa-error-message')
+    end
+
+    it 'outputs a label' do
+      expect(result).to have_element(:label, class: 'usa-label', for: 'object_first_name')
+    end
+
+    it 'includes an example in the hint' do
+      expect(result).to have_element(:p, text: "For example, 123456789")
+    end
+  end
+
+  describe '#yes_no' do
+    let(:result) { builder.yes_no(:first_name, legend: 'Custom legend') }
+
+    it 'outputs radio buttons for yes and no' do
+      expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input', value: 'true', name: 'object[first_name]')
+      expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input', value: 'false', name: 'object[first_name]')
+
+      expect(result).to have_element(:label, text: 'Yes', class: 'usa-radio__label')
+      expect(result).to have_element(:label, text: 'No', class: 'usa-radio__label')
+
+      expect(result).to have_element(:legend, text: 'Custom legend', class: 'usa-legend')
+    end
+
+    context 'with custom labels' do
+      let(:result) { builder.yes_no(:first_name,
+        yes_options: { label: "Yes, I've taken leave before" },
+        no_options: { label: "No, I haven't taken leave before" }
+      ) }
+
+      it 'outputs radio buttons with custom labels' do
+        expect(result).to have_element(:label, text: "Yes, I've taken leave before")
+        expect(result).to have_element(:label, text: "No, I haven't taken leave before")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Work related to #33 

## Changes

- Add tax_id_field to us form builder
- Add tests to catch missing content
- Add missing content

## Context for reviewers

This PR attempts to complete the work started in https://github.com/navapbc/template-application-rails/pull/62/files. I moved the work to platform-test so that I can use the Make commands to test and lint before moving the changes back to template-application-rails.

I removed sassc here too even though there's already an active PR for removing it (https://github.com/navapbc/platform-test/pull/200) since it was interfering with me running locally

## Testing

see https://github.com/navapbc/platform-test/pull/202