### PR TITLE
Add memorable_date to uswds form builder

### DIFF
--- a/template/{{app_name}}/app/helpers/uswds_form_builder.rb
+++ b/template/{{app_name}}/app/helpers/uswds_form_builder.rb
@@ -49,7 +49,7 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
       end
 
       form_group(attribute, options[:group_options] || {}) do
-        us_text_field_label(attribute, label_text, label_options) + super(attribute, field_options)
+        content
       end
     end
   end

--- a/template/{{app_name}}/app/previews/memorable_date_preview.rb
+++ b/template/{{app_name}}/app/previews/memorable_date_preview.rb
@@ -1,0 +1,59 @@
+class MemorableDatePreview < Lookbook::Preview
+  layout "component_preview"
+
+  # @!group Variations
+
+  def empty
+    render template: "previews/_memorable_date", locals: { model: new_model }
+  end
+
+  def filled
+    model = new_model
+    model.date_of_birth = Date.new(1990, 2, 28)
+    render template: "previews/_memorable_date", locals: { model: model }
+  end
+
+  def invalid
+    model = new_model
+    model.date_of_birth = { year: 1990, month: 2, day: 31 }
+    model.valid?
+    render template: "previews/_memorable_date", locals: { model: model }
+  end
+
+  # @!endgroup
+
+  private
+
+  def new_model
+    @model = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      attribute :date_of_birth, :date
+
+      validate :date_of_birth_is_valid
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "TestModel")
+      end
+
+      def date_of_birth_is_valid
+        if date_of_birth_before_type_cast.present? && date_of_birth.nil?
+          errors.add(:date_of_birth, :invalid_memorable_date)
+        end
+      end
+
+      # Simulate the behavior of ActiveRecord's before_type_cast
+
+      def date_of_birth=(value)
+        @date_of_birth_before_type_cast = value
+        super
+      end
+
+      def date_of_birth_before_type_cast
+        @date_of_birth_before_type_cast
+      end
+    end.new
+  end
+end

--- a/template/{{app_name}}/app/views/previews/_memorable_date.html.erb
+++ b/template/{{app_name}}/app/views/previews/_memorable_date.html.erb
@@ -1,0 +1,3 @@
+<%= us_form_with(model: model, url: false) do |f| %>
+  <%= f.memorable_date :date_of_birth, { label: t('.date_of_birth') } %>
+<% end %>

--- a/template/{{app_name}}/config/locales/defaults/en.yml
+++ b/template/{{app_name}}/config/locales/defaults/en.yml
@@ -1,36 +1,4 @@
 en:
-  activerecord:
-    errors:
-      messages:
-        # Override error messages: https://guides.rubyonrails.org/i18n.html#error-message-interpolation
-        # blank: "'%{attribute}' can't be blank"
-        #
-        # i18n strings for ActiveStorageValidation
-        # See: https://github.com/igorkasyanchuk/active_storage_validations
-        content_type_invalid: "has an invalid content type"
-        file_size_not_less_than: "file size must be less than %{max_size} (current size is %{file_size})"
-        file_size_not_less_than_or_equal_to: "file size must be less than or equal to %{max_size} (current size is %{file_size})"
-        file_size_not_greater_than: "file size must be greater than %{min_size} (current size is %{file_size})"
-        file_size_not_greater_than_or_equal_to: "file size must be greater than or equal to %{min_size} (current size is %{file_size})"
-        file_size_not_between: "file size must be between %{min_size} and %{max_size} (current size is %{file_size})"
-        limit_out_of_range: "total number is out of range"
-        image_metadata_missing: "is not a valid image"
-        dimension_min_inclusion: "must be greater than or equal to %{width} x %{height} pixel."
-        dimension_max_inclusion: "must be less than or equal to %{width} x %{height} pixel."
-        dimension_width_inclusion: "width is not included between %{min} and %{max} pixel."
-        dimension_height_inclusion: "height is not included between %{min} and %{max} pixel."
-        dimension_width_greater_than_or_equal_to: "width must be greater than or equal to %{length} pixel."
-        dimension_height_greater_than_or_equal_to: "height must be greater than or equal to %{length} pixel."
-        dimension_width_less_than_or_equal_to: "width must be less than or equal to %{length} pixel."
-        dimension_height_less_than_or_equal_to: "height must be less than or equal to %{length} pixel."
-        dimension_width_equal_to: "width must be equal to %{length} pixel."
-        dimension_height_equal_to: "height must be equal to %{length} pixel."
-        aspect_ratio_not_square: "must be a square image"
-        aspect_ratio_not_portrait: "must be a portrait image"
-        aspect_ratio_not_landscape: "must be a landscape image"
-        aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
-        aspect_ratio_unknown: "has an unknown aspect ratio"
-        image_not_processable: "is not a valid image"
   auth:
     errors:
       messages:
@@ -50,6 +18,38 @@ en:
     attributes:
       spam_trap:
         present: "This field should be left empty. It is intended to prevent bots from submitting spam using this form."
+    messages:
+      # Override error messages: https://guides.rubyonrails.org/i18n.html#error-message-interpolation
+      # blank: "'%{attribute}' can't be blank"
+      #
+      # i18n strings for ActiveStorageValidation
+      # See: https://github.com/igorkasyanchuk/active_storage_validations
+      content_type_invalid: "has an invalid content type"
+      file_size_not_less_than: "file size must be less than %{max_size} (current size is %{file_size})"
+      file_size_not_less_than_or_equal_to: "file size must be less than or equal to %{max_size} (current size is %{file_size})"
+      file_size_not_greater_than: "file size must be greater than %{min_size} (current size is %{file_size})"
+      file_size_not_greater_than_or_equal_to: "file size must be greater than or equal to %{min_size} (current size is %{file_size})"
+      file_size_not_between: "file size must be between %{min_size} and %{max_size} (current size is %{file_size})"
+      limit_out_of_range: "total number is out of range"
+      image_metadata_missing: "is not a valid image"
+      dimension_min_inclusion: "must be greater than or equal to %{width} x %{height} pixel."
+      dimension_max_inclusion: "must be less than or equal to %{width} x %{height} pixel."
+      dimension_width_inclusion: "width is not included between %{min} and %{max} pixel."
+      dimension_height_inclusion: "height is not included between %{min} and %{max} pixel."
+      dimension_width_greater_than_or_equal_to: "width must be greater than or equal to %{length} pixel."
+      dimension_height_greater_than_or_equal_to: "height must be greater than or equal to %{length} pixel."
+      dimension_width_less_than_or_equal_to: "width must be less than or equal to %{length} pixel."
+      dimension_height_less_than_or_equal_to: "height must be less than or equal to %{length} pixel."
+      dimension_width_equal_to: "width must be equal to %{length} pixel."
+      dimension_height_equal_to: "height must be equal to %{length} pixel."
+      aspect_ratio_not_square: "must be a square image"
+      aspect_ratio_not_portrait: "must be a portrait image"
+      aspect_ratio_not_landscape: "must be a landscape image"
+      aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
+      aspect_ratio_unknown: "has an unknown aspect ratio"
+      image_not_processable: "is not a valid image"
+      invalid_date: "is not a valid date. Use the format: mm/dd/yyyy"
+      invalid_memorable_date: "is not a valid date"
   helpers:
     submit:
       create: "Submit"
@@ -62,5 +62,6 @@ en:
     boolean_true: "Yes"
     boolean_false: "No"
     date_picker_format: "Format: mm/dd/yyyy"
+    memorable_date_hint: "For example: January 19 2000"
     optional: "Optional"
     tax_id_format: "For example, 123456789"


### PR DESCRIPTION
## Ticket

n/a

## Changes

- Add memorable_date method to USWDS form builder
- Add Lookbook preview
- Add default content

## Context for reviewers

Implements https://designsystem.digital.gov/components/memorable-date/

## Testing

Tested on https://github.com/navapbc/pfml-starter-kit-app/pull/302