### PR TITLE
Require SSL connections to databases in deployed environments

### DIFF
--- a/template/{{app_name}}/config/database.yml
+++ b/template/{{app_name}}/config/database.yml
@@ -94,3 +94,6 @@ production:
   # Enable AWS RDS IAM Auth token generator
   # For more details, see: https://github.com/haines/pg-aws_rds_iam
   aws_rds_iam_auth_token_generator: default
+
+  # Require SSL when connecting to the database
+  sslmode: require


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

Came up since we were seeing DB connection issues, and [we already require on Flask template](https://github.com/navapbc/template-application-flask/blob/2292f463375b8f7e3a0f510babb4c3e75a86d98e/template/%7B%7Bapp_name%7D%7D/src/adapters/db/clients/postgres_config.py#L21) so seems consistent to do it here too

## Testing

Tested on flex-demo-sdk