### PR TITLE
Force RAILS_ENV=test in RSpec config

### DIFF
--- a/template/{{app_name}}/bin/rspec
+++ b/template/{{app_name}}/bin/rspec
@@ -1,7 +1,3 @@
 #!/usr/bin/env sh
 
-# Since CI runs tests from within the container, which
-# sets RAILS_ENV to development, we need to override it:
-export RAILS_ENV=test
-
 bundle exec rspec --format documentation "$@"

--- a/template/{{app_name}}/spec/rails_helper.rb
+++ b/template/{{app_name}}/spec/rails_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.start 'rails' do
 end
 
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
It's not clear to me why you'd ever run the test suite against a different `RAILS_ENV` setting. And even if you did want to do that, why you'd want the test suite configuration for selecting that `RAILS_ENV` to use be the same environment variable the real application uses, which creates conflicts and confusion when you want to run both the application and the test suite in the same host environment (i.e., during all of development).

The test suite should be as self contained as possible. And while not the end of the world, shouldn't *have* to use a wrapper script for the test suite to minimally function.

## Testing

https://github.com/navapbc/community-engagement-medicaid/pull/12