### PR TITLE
Create Auth::CognitoAdapater::Config and fill with dummy values in tests

### DIFF
--- a/template/{{app_name}}/spec/adapters/auth/cognito_adapter/config_spec.rb
+++ b/template/{{app_name}}/spec/adapters/auth/cognito_adapter/config_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Auth::CognitoAdapter::Config do
+  describe "#from_env" do
+    it "handles complete env vars" do
+      stub_const('ENV', { 'COGNITO_CLIENT_ID' => 'foo', 'COGNITO_CLIENT_SECRET' => "my-secret", "COGNITO_USER_POOL_ID" => "baz" })
+
+      config = described_class.from_env()
+
+      expect(config).to eq(described_class.new(client_id: "foo", client_secret: "my-secret", user_pool_id: "baz"))
+    end
+
+    it "handles partial env vars" do
+      stub_const('ENV', { 'COGNITO_CLIENT_ID' => 'foo', 'COGNITO_CLIENT_SECRET' => "my-secret" })
+
+      config = described_class.from_env()
+
+      expect(config).to eq(described_class.new(client_id: "foo", client_secret: "my-secret", user_pool_id: nil))
+    end
+
+    it "handles empty env vars" do
+      stub_const('ENV', {})
+
+      config = described_class.from_env()
+
+      expect(config).to eq(described_class.new(client_id: nil, client_secret: nil, user_pool_id: nil))
+    end
+  end
+end

--- a/template/{{app_name}}/spec/adapters/auth/cognito_adapter_spec.rb
+++ b/template/{{app_name}}/spec/adapters/auth/cognito_adapter_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Auth::CognitoAdapter do
   let(:mock_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
-  let(:adapter) { described_class.new(client: mock_client) }
+  let(:dummy_config) { Auth::CognitoAdapter::Config.new(client_id: "Foo", client_secret: "Bar", user_pool_id: "Baz") }
+  let(:adapter) { described_class.new(client: mock_client, config: dummy_config) }
   let(:email) { "test@example.com" }
 
   describe "#associate_software_token" do


### PR DESCRIPTION
Previously the tests would expose whatever config values are active in the runtime environment, which is dangerous. It means running the tests could have side effects/mutate state in real resources. We mock the Cognito client itself in the tests, which should avoid most of the issues, but it's still dangerous to expose potentially real config values to the test suite. It also means the tests are less isolated from local configuration. So avoid these issues and explicitly pass in dummy configuration.

The Config object makes the required configuration more explicit for users, as well as provides a nicer abstraction for mocking/testing the adapter.

It would be prudent to eventually ensure that no environment variables are exposed to tests, except specifically configured ones, and have better env var testing tools.

## Testing

https://github.com/navapbc/community-engagement-medicaid/pull/13