### PR TITLE
RSpec util for exceptions

### DIFF
--- a/template/{{app_name}}/.rubocop.yml
+++ b/template/{{app_name}}/.rubocop.yml
@@ -8,3 +8,7 @@ RSpec/ExampleLength:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/NoExpectationExample:
+  AllowedPatterns:
+    - assert_
+    - is_expected_in_block

--- a/template/{{app_name}}/spec/spec_helper.rb
+++ b/template/{{app_name}}/spec/spec_helper.rb
@@ -46,6 +46,10 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # https://github.com/rspec/rspec-expectations/issues/805#issuecomment-1792552900
+  # https://github.com/rspec/rspec/pull/150
+  config.include(Module.new { def is_expected_in_block = expect { subject } })
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Motivated initially for testing pundit unauthorized exceptions, like:

```
it { is_expected_in_block.to raise_error(Pundit::NotAuthorizedError) }
```

Which matches well with typical `is_expected` cases, like:

```
it { is_expected.to permit_all_actions }
```

## Testing

https://github.com/navapbc/community-engagement-medicaid/pull/14