### PR TITLE
Enable Style/RedundantSelf RuboCop cop

### DIFF
--- a/template/{{app_name}}/.rubocop.yml
+++ b/template/{{app_name}}/.rubocop.yml
@@ -22,3 +22,5 @@ RSpecRails/HttpStatusNameConsistency:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
+Style/RedundantSelf:
+  Enabled: true

--- a/template/{{app_name}}/app/helpers/uswds_form_builder.rb
+++ b/template/{{app_name}}/app/helpers/uswds_form_builder.rb
@@ -10,8 +10,8 @@ class UswdsFormBuilder < ActionView::Helpers::FormBuilder
 
   def initialize(*args)
     super
-    self.options[:html] ||= {}
-    self.options[:html][:class] ||= "usa-form usa-form--large"
+    options[:html] ||= {}
+    options[:html][:class] ||= "usa-form usa-form--large"
   end
 
   ########################################


### PR DESCRIPTION
Enables the `Style/RedundantSelf` cop in `RuboCop` configuration and removes redundant self references in `UswdsFormBuilder#initialize`.

This cop helps maintain cleaner, more idiomatic Ruby code by flagging unnecessary uses of `self.` In Ruby, explicit self is only required when calling setter methods or disambiguating in specific contexts. Removing redundant self references reduces visual noise and aligns with Ruby community style conventions.

**References:**
https://docs.rubocop.org/rubocop/cops_style.html#styleredundantself 
https://rubystyle.guide/#no-self-unless-required

