### PR TITLE
Add Azure EntraID database auth support

### DIFF
--- a/template-only-docs/Deployment.md
+++ b/template-only-docs/Deployment.md
@@ -11,7 +11,7 @@
 
 ## Deploying using the Platform Infrastructure Template
 
-This template can be deployed using the [Nava Platform Infrastructure Template](https://github.com/navapbc/template-infra). Using the infrastructure template will handle creating and configuring all of the resources required in AWS.
+This template can be deployed using the [Nava AWS Platform Infrastructure Template](https://github.com/navapbc/template-infra) or [Nava Azure Platform Infrastructure Template](https://github.com/navapbc/template-infra-azure). Using the infrastructure template will handle creating and configuring all of the resources required.
 
 While following the [infrastructure template installation instructions](https://github.com/navapbc/template-infra?tab=readme-ov-file#installation) and [setup instructions](https://github.com/navapbc/template-infra/blob/main/infra/README.md), use the following configuration:
 
@@ -37,7 +37,41 @@ While following the [infrastructure template installation instructions](https://
       secret_store_name = "/${var.app_name}-${var.environment}/service/rails-secret-key-base"
     }
     ```
+    1. Configure database authentication (see [Database Integration](#database-integration) below).
 1. Follow the infrastructure template instructions to configure [custom domains](https://github.com/navapbc/template-infra/blob/main/docs/infra/set-up-custom-domains.md) and [https support](https://github.com/navapbc/template-infra/blob/main/docs/infra/https-support.md).
+
+### Database Integration
+
+The application supports multiple database authentication methods via the `DB_AUTH_METHOD` environment variable. Set it in `default_extra_environment_variables` inside `/infra/<APP_NAME>/app-config/env-config/environment-variables.tf`:
+
+| `DB_AUTH_METHOD` | Description | When to use |
+|---|---|---|
+| *(unset or omitted)* | Use `DB_PASSWORD` as-is | Local development / password-based auth |
+| `aws_iam` | AWS RDS IAM auth token | Deployed on AWS with RDS |
+| `azure_entra` | Azure Managed Identity token via MS Entra ID | Deployed on Azure with Azure Database for PostgreSQL |
+
+**AWS (RDS IAM)**:
+```terraform
+default_extra_environment_variables = {
+  DB_AUTH_METHOD = "aws_iam"
+}
+```
+
+**Azure (Entra ID)**:
+```terraform
+default_extra_environment_variables = {
+  DB_AUTH_METHOD        = "azure_entra"
+  AZURE_DB_RESOURCE_URI = "https://ossrdbms-aad.database.windows.net"
+}
+```
+
+`AZURE_DB_RESOURCE_URI` is the audience URI used when requesting an access token from MS Entra ID. The value depends on which Azure PostgreSQL service is being used:
+
+| Azure PostgreSQL service | `AZURE_DB_RESOURCE_URI` |
+|---|---|
+| Azure Database for PostgreSQL Flexible Server | `https://ossrdbms-aad.database.windows.net` |
+
+Consult the [Azure documentation](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication) if using a different service.
 
 ## Enabling Lookbook on the dev environment
 
@@ -51,5 +85,6 @@ service_override_extra_environment_variables = {
 
 ## Deploying using another method
 
+### AWS
 - AWS Cognito requires a lot of configuration to work correctly. See the Nava Platform infrastructure template for example configuration.
 - If you are deploying using AWS ECS, but don't want to use the Platform infrastructure template, pass in environment variables and secrets using the ECS task definition. Use the `environment` key for environment variables and the `secrets` key with `valueFrom` for secrets.

--- a/template/{{app_name}}/README.md.jinja
+++ b/template/{{app_name}}/README.md.jinja
@@ -9,6 +9,8 @@ This is a [Ruby on Rails](https://rubyonrails.org/) application. It includes:
   - Active Storage configuration with AWS S3
   - Action Mailer configuration with AWS SES
   - Authentication with [devise](https://github.com/heartcombo/devise) and AWS Cognito
+- Integration with Azure services, including
+  - Database integration with Azure PostgreSQL using Entra ID
 - Internationalization (i18n)
 - Authorization using [pundit](https://github.com/varvet/pundit)
 - Linting and code formatting using [rubocop](https://rubocop.org/)
@@ -52,6 +54,7 @@ Below are the primary directories to be aware of when working on the app:
   - By default, `docker` is used. To change this, set the `CONTAINER_CMD` variable to `finch` (or whatever your container runtime is) in the shell.
 - An AWS account with a Cognito User Pool and App Client configured
   - By default, the application configures authentication using AWS Cognito
+- Or an Azure subscription
 
 ### 💾 Setup
 
@@ -104,6 +107,31 @@ AUTH_ADAPTER=cognito
 ```
 
 You will need to set the other cognito variables as well; setting `AUTH_ADAPTER` alone will merely set the auth flow to cognito, not enable cognito log in.
+
+#### Database Authentication
+
+The application supports three database authentication methods, controlled by the `DB_AUTH_METHOD` environment variable in your `.env` file:
+
+| `DB_AUTH_METHOD` | Description | When to use |
+|---|---|---|
+| *(unset or blank)* | Use `DB_PASSWORD` as-is | Local development |
+| `aws_iam` | AWS RDS IAM auth token | Deployed on AWS |
+| `azure_entra` | Azure Managed Identity token via MS Entra ID | Deployed on Azure |
+
+**Local development** (default): Leave `DB_AUTH_METHOD` unset in your `.env`. The app uses `DB_PASSWORD` directly — no further configuration needed.
+
+**AWS (RDS IAM)**: Set the following in your `.env`:
+```
+DB_AUTH_METHOD=aws_iam
+```
+
+**Azure (Entra ID)**: Set the following in your `.env`:
+```
+DB_AUTH_METHOD=azure_entra
+AZURE_DB_RESOURCE_URI=https://ossrdbms-aad.database.windows.net
+```
+
+`AZURE_DB_RESOURCE_URI` is the audience URI used when requesting an access token from MS Entra ID. For Azure Database for PostgreSQL Flexible Server the value is `https://ossrdbms-aad.database.windows.net`. Consult the Azure documentation if using a different database service.
 
 #### IDE tips
 

--- a/template/{{app_name}}/config/database.yml
+++ b/template/{{app_name}}/config/database.yml
@@ -91,9 +91,7 @@ mock-production:
 #
 production:
   <<: *default
-  # Enable AWS RDS IAM Auth token generator
-  # For more details, see: https://github.com/haines/pg-aws_rds_iam
-  aws_rds_iam_auth_token_generator: default
-
+  # Password is injected at runtime via the database_auth.rb initializer strategy
+  # (Azure Managed Identity or AWS IAM token, controlled by DB_AUTH_METHOD env var)
   # Require SSL when connecting to the database
   sslmode: require

--- a/template/{{app_name}}/config/initializers/database_auth.rb
+++ b/template/{{app_name}}/config/initializers/database_auth.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Database authentication strategy
+#
+# Patches PG::Connection to inject a short-lived authentication token as the
+# password on every new connection. The strategy is selected via the
+# DB_AUTH_METHOD environment variable:
+#
+#   DB_AUTH_METHOD=azure_entra  — Azure Managed Identity token (Azure Container Apps)
+#   DB_AUTH_METHOD=aws_iam      — AWS RDS IAM auth token
+#   (unset)                     — use DB_PASSWORD as-is (local development)
+#
+# Azure Entra prerequisites:
+#   IDENTITY_ENDPOINT   — set automatically by Azure Container Apps
+#   IDENTITY_HEADER     — set automatically by Azure Container Apps
+#   AZURE_CLIENT_ID     — client ID of the user-assigned managed identity
+#
+# AWS IAM prerequisites:
+#   AWS_REGION          — AWS region where the RDS instance lives
+#   DB_HOST             — RDS instance hostname
+#   DB_PORT             — RDS instance port (default 5432)
+#   DB_USER             — DB username matching the IAM role
+
+module DatabaseAuth
+  class AzureEntra
+    RESOURCE = "https://ossrdbms-aad.database.windows.net"
+
+    def token
+      endpoint  = ENV.fetch("IDENTITY_ENDPOINT")
+      header    = ENV.fetch("IDENTITY_HEADER")
+      client_id = ENV.fetch("AZURE_CLIENT_ID")
+
+      uri = URI(endpoint)
+      uri.query = URI.encode_www_form(
+        resource:  RESOURCE,
+        client_id: client_id,
+        "api-version" => "2019-08-01"
+      )
+
+      response = Net::HTTP.start(uri.host, uri.port) do |http|
+        request = Net::HTTP::Get.new(uri)
+        request["X-IDENTITY-HEADER"] = header
+        http.request(request)
+      end
+
+      raise "Azure MSI token request failed: #{response.code} #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body).fetch("access_token")
+    end
+  end
+
+  class AwsIAM
+    def token
+      require "pg-aws_rds_iam"
+      require "aws-sdk-rds"
+      generator = Aws::RDS::AuthTokenGenerator.new(
+        credentials: Aws::InstanceProfileCredentials.new
+      )
+      generator.auth_token(
+        region:   ENV.fetch("AWS_REGION"),
+        endpoint: "#{ENV.fetch("DB_HOST")}:#{ENV.fetch("DB_PORT", "5432")}",
+        user_name: ENV.fetch("DB_USER")
+      )
+    end
+  end
+end
+
+db_auth_method = ENV["DB_AUTH_METHOD"]
+
+if db_auth_method.present?
+  strategy = case db_auth_method
+  when "azure_entra" then DatabaseAuth::AzureEntra.new
+  when "aws_iam"     then DatabaseAuth::AwsIAM.new
+  else raise ArgumentError, "Unknown DB_AUTH_METHOD: #{db_auth_method}. Valid values: azure_entra, aws_iam"
+  end
+
+  PG::Connection.singleton_class.prepend(Module.new do
+    define_method(:parse_connect_args) do |*args|
+      conn_string = super(*args)
+      token = strategy.token
+      # Append password to the libpq keyword=value connection string.
+      # Azure AD tokens are base64url-encoded JWTs (no spaces or single quotes),
+      # so single-quoting is safe without additional escaping.
+      "#{conn_string} password='#{token}'"
+    end
+  end)
+end

--- a/template/{{app_name}}/config/initializers/database_auth.rb
+++ b/template/{{app_name}}/config/initializers/database_auth.rb
@@ -23,7 +23,7 @@
 
 module DatabaseAuth
   class AzureEntra
-    RESOURCE = "https://ossrdbms-aad.database.windows.net"
+    RESOURCE = ENV.fetch("AZURE_DB_RESOURCE_URI")
 
     def token
       endpoint  = ENV.fetch("IDENTITY_ENDPOINT")

--- a/template/{{app_name}}/config/initializers/database_auth.rb
+++ b/template/{{app_name}}/config/initializers/database_auth.rb
@@ -23,16 +23,15 @@
 
 module DatabaseAuth
   class AzureEntra
-    RESOURCE = ENV.fetch("AZURE_DB_RESOURCE_URI")
-
     def token
+      resource  = ENV.fetch("AZURE_DB_RESOURCE_URI")
       endpoint  = ENV.fetch("IDENTITY_ENDPOINT")
       header    = ENV.fetch("IDENTITY_HEADER")
       client_id = ENV.fetch("AZURE_CLIENT_ID")
 
       uri = URI(endpoint)
       uri.query = URI.encode_www_form(
-        resource:  RESOURCE,
+        resource:  resource,
         client_id: client_id,
         "api-version" => "2019-08-01"
       )

--- a/template/{{app_name}}/config/initializers/database_auth.rb
+++ b/template/{{app_name}}/config/initializers/database_auth.rb
@@ -50,10 +50,8 @@ module DatabaseAuth
 
   class AwsIAM
     def token
-      require "pg-aws_rds_iam"
-      require "aws-sdk-rds"
       generator = Aws::RDS::AuthTokenGenerator.new(
-        credentials: Aws::InstanceProfileCredentials.new
+        credentials: Aws::CredentialProviderChain.new.resolve
       )
       generator.auth_token(
         region:   ENV.fetch("AWS_REGION"),

--- a/template/{{app_name}}/local.env.example.jinja
+++ b/template/{{app_name}}/local.env.example.jinja
@@ -46,6 +46,15 @@ DB_NAME=app
 DB_USER=app
 DB_PASSWORD=secret123
 
+# DB_AUTH_METHOD=azure_entra  — Azure Managed Identity token (Azure Container Apps)
+# DB_AUTH_METHOD=aws_iam      — AWS RDS IAM auth token
+# (unset)                     — use DB_PASSWORD as-is (local development)
+DB_AUTH_METHOD=
+
+# Resource Identifier URI (audience) used when requesting an access token from
+# MS Entra ID for authenticating to PostgreSQL using Azure AD Auth.
+# AZURE_DB_RESOURCE_URI=https://ossrdbms-aad.database.windows.net
+
 ############################
 # Lookbook
 ############################

--- a/template/{{app_name}}/local.env.example.jinja
+++ b/template/{{app_name}}/local.env.example.jinja
@@ -49,11 +49,13 @@ DB_PASSWORD=secret123
 # DB_AUTH_METHOD=azure_entra  — Azure Managed Identity token (Azure Container Apps)
 # DB_AUTH_METHOD=aws_iam      — AWS RDS IAM auth token
 # (unset)                     — use DB_PASSWORD as-is (local development)
-DB_AUTH_METHOD=
 
 # Resource Identifier URI (audience) used when requesting an access token from
-# MS Entra ID for authenticating to PostgreSQL using Azure AD Auth.
-# AZURE_DB_RESOURCE_URI=https://ossrdbms-aad.database.windows.net
+# MS Entra ID for authenticating to Azure PostgreSQL using Azure AD Auth.
+# For Azure Database for PostgreSQL Flexible Server the value is
+# `https://ossrdbms-aad.database.windows.net`.
+# Consult the Azure documentation if using a different database service.
+# AZURE_DB_RESOURCE_URI="https://ossrdbms-aad.database.windows.net"
 
 ############################
 # Lookbook


### PR DESCRIPTION

## Ticket

- Resolves ticket #156 

## Changes

- Add database_auth.rb initializer that supports both Azure EntraID and AWS IAM token-based authentication, selected via DB_AUTH_METHOD env var
- Update database.yml to remove aws_rds_iam_auth_token_generator and reference database_auth.rb for token injection
- Update documentations with instructions to set DB_AUTH_METHOD and AZURE_DB_RESOURCE_URI environment variables

## Context for reviewers

This change ensures rails template apps authenticates to PostgreSQL database using Azure EntraID as well as AWS IAM DB Auth 

## Testing

https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679
https://github.com/navapbc/akhr1/pull/2#issue-4113889857