### PR TITLE
fix redirect URLs and config to use the set APP_HOST env variable

### DIFF
--- a/template/{{app_name}}/app/controllers/application_controller.rb
+++ b/template/{{app_name}}/app/controllers/application_controller.rb
@@ -28,4 +28,40 @@ class ApplicationController < ActionController::Base
 
     users_account_path
   end
+
+  # Intercept redirect_to to replace the host with APP_HOST (the public hostname).
+  def redirect_to(options = {}, response_options_and_flash = {})
+    app_host = ENV["APP_HOST"]
+    if app_host.present?
+      options = case options
+      when String
+        if options.start_with?("http://", "https://")
+          options.sub(%r{\Ahttps?://[^/]+}, "https://#{app_host}")
+        elsif options.start_with?("/")
+          "https://#{app_host}#{options}"
+        else
+          options
+        end
+      when Hash
+        { host: app_host, protocol: "https" }.merge(options)
+      else
+        options
+      end
+      response_options_and_flash = response_options_and_flash.merge(allow_other_host: true)
+    end
+    super
+  end
+
+  private
+
+  # Compare the Origin header against the configured APP_HOST (the public hostname) instead.
+  def valid_request_origin?
+    app_host = ENV["APP_HOST"]
+    if app_host.present?
+      request.origin.nil? || request.origin == "#{request.scheme}://#{app_host}"
+    else
+      super
+    end
+  end
+
 end

--- a/template/{{app_name}}/app/controllers/users/mfa_controller.rb
+++ b/template/{{app_name}}/app/controllers/users/mfa_controller.rb
@@ -34,7 +34,7 @@ class Users::MfaController < ApplicationController
     # forcing the user to log in again
     if current_user.access_token_expires_within_minutes?(current_user.access_token, 5)
       sign_out(current_user)
-      redirect_to new_user_session_path
+      redirect_to new_user_session_url
       return
     end
 
@@ -58,12 +58,12 @@ class Users::MfaController < ApplicationController
       return redirect_to({ action: :new }, flash: { errors: [ e.message ] })
     end
 
-    redirect_to root_path, { notice: I18n.t("users.mfa.create.success") }
+    redirect_to root_url, { notice: I18n.t("users.mfa.create.success") }
   end
 
   def destroy
     auth_service.disable_software_token(current_user)
-    redirect_to users_account_path, notice: I18n.t("users.accounts.edit.mfa_successfully_disabled")
+    redirect_to users_account_url, notice: I18n.t("users.accounts.edit.mfa_successfully_disabled")
   end
 
   private

--- a/template/{{app_name}}/app/controllers/users/passwords_controller.rb
+++ b/template/{{app_name}}/app/controllers/users/passwords_controller.rb
@@ -24,7 +24,7 @@ class Users::PasswordsController < ApplicationController
       return render :forgot, status: :unprocessable_content
     end
 
-    redirect_to users_reset_password_path
+    redirect_to users_reset_password_url
   end
 
   def reset
@@ -50,7 +50,7 @@ class Users::PasswordsController < ApplicationController
       return render :reset, status: :unprocessable_content
     end
 
-    redirect_to new_user_session_path, notice: I18n.t("users.passwords.reset.success")
+    redirect_to new_user_session_url, notice: I18n.t("users.passwords.reset.success")
   end
 
   private

--- a/template/{{app_name}}/app/controllers/users/registrations_controller.rb
+++ b/template/{{app_name}}/app/controllers/users/registrations_controller.rb
@@ -26,7 +26,7 @@ class Users::RegistrationsController < ApplicationController
       return render :new, status: :unprocessable_content
     end
 
-    redirect_to users_verify_account_path
+    redirect_to users_verify_account_url
   end
 
   def new_account_verification
@@ -50,7 +50,7 @@ class Users::RegistrationsController < ApplicationController
       return render :new_account_verification, status: :unprocessable_content
     end
 
-    redirect_to new_user_session_path
+    redirect_to new_user_session_url
   end
 
   def resend_verification_code
@@ -65,7 +65,7 @@ class Users::RegistrationsController < ApplicationController
     auth_service.resend_verification_code(email)
 
     flash[:notice] = I18n.t("users.registrations.new_account_verification.resend_success")
-    redirect_to users_verify_account_path
+    redirect_to users_verify_account_url
   end
 
   private

--- a/template/{{app_name}}/app/controllers/users/sessions_controller.rb
+++ b/template/{{app_name}}/app/controllers/users/sessions_controller.rb
@@ -22,7 +22,7 @@ class Users::SessionsController < Devise::SessionsController
         @form.password
       )
     rescue Auth::Errors::UserNotConfirmed => e
-      return redirect_to users_verify_account_path
+      return redirect_to users_verify_account_url
     rescue Auth::Errors::BaseAuthError => e
       flash.now[:errors] = [ e.message ]
       return render :new, status: :unprocessable_content
@@ -31,7 +31,7 @@ class Users::SessionsController < Devise::SessionsController
     unless response[:user].present?
       session[:challenge_session] = response[:session]
       session[:challenge_email] = @form.email
-      return redirect_to session_challenge_path
+      return redirect_to session_challenge_url
     end
 
     auth_user(response[:user], response[:access_token])
@@ -40,7 +40,7 @@ class Users::SessionsController < Devise::SessionsController
   # Show MFA
   def challenge
     if session[:challenge_session].nil?
-      return redirect_to new_user_session_path
+      return redirect_to new_user_session_url
     end
 
     @form = Users::AuthAppCodeForm.new

--- a/template/{{app_name}}/config/environments/production.rb.jinja
+++ b/template/{{app_name}}/config/environments/production.rb.jinja
@@ -50,7 +50,12 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
+  config.assume_ssl = true
+
+  # Azure Application Gateway sets Host: <container-app-fqdn> on backend connections.
+  # Set the default URL host to APP_HOST so that redirects use the public hostname
+  # instead of the internal Container App FQDN.
+  config.action_dispatch.default_url_options = { host: ENV["APP_HOST"] }
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true


### PR DESCRIPTION
## Ticket

- Resolves [template #44](https://github.com/navapbc/template-infra-azure/issues/44#issue-4319413970)

## Changes

- application_controller.rb: override redirect_to to rewrite the host to APP_HOST for absolute URL strings; override valid_request_origin? to compare request.origin against APP_HOST to prevent CSRF 422 errors
- production.rb: enable config.assume_ssl and set config.action_dispatch.default_url_options to APP_HOST so Rails builds correct absolute URLs for redirects and mailer links
- users/sessions_controller.rb, mfa_controller.rb, passwords_controller.rb, registrations_controller.rb: change redirect_to calls from *_path (relative) to *_url (absolute) so the ApplicationController#redirect_to override can rewrite the host

## Context for reviewers

Azure Application Gateway sets Host: <container-app-fqdn> on backend connections, causing redirects to use the internal Container App FQDN instead of the public APP_HOST.

## Testing

https://github.com/navapbc/akhr1/tree/johan/initial-oscer-setup