### PR TITLE
Add rack-timeout to avoid LB timeout

### DIFF
--- a/template/{{app_name}}/Gemfile
+++ b/template/{{app_name}}/Gemfile
@@ -16,6 +16,9 @@ gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 
+# Terminate requests that run longer than the load balancer timeout
+gem "rack-timeout"
+
 # Support Sass stylesheets
 gem "cssbundling-rails", "~> 1.4"
 

--- a/template/{{app_name}}/Gemfile.lock
+++ b/template/{{app_name}}/Gemfile.lock
@@ -339,6 +339,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-timeout (0.7.0)
     rackup (2.3.1)
       rack (>= 3)
     rails (8.0.5)
@@ -563,6 +564,7 @@ DEPENDENCIES
   puma (>= 5.0)
   pundit
   pundit-matchers
+  rack-timeout
   rails (~> 8.0.5, >= 8.0.5)
   rails-erd
   route_translator


### PR DESCRIPTION
## Summary

- Adds `rack-timeout` gem to all environments so the app can terminate long-running requests before the load balancer silently drops the TCP connection
- Included in all environments (not just production) so local dev mirrors prod behavior
- No initializer needed — rack-timeout auto-inserts itself and reads `RACK_TIMEOUT_SERVICE_TIMEOUT` from the environment (default: 15s)

## Reviewer notes

To disable the timeout locally (e.g. when using a debugger), set `RACK_TIMEOUT_SERVICE_TIMEOUT=0` in `.env`.